### PR TITLE
Replace ioutils.TempFile with os.CreateTemp

### DIFF
--- a/workspaces/server/internal/probe/probe.go
+++ b/workspaces/server/internal/probe/probe.go
@@ -2,7 +2,6 @@ package probe
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 )
 
@@ -23,7 +22,7 @@ func (lf *LiveFile) Create() (*os.File, error) {
 	}
 
 	// attempt to create our temporarry file
-	liveFile, err := ioutil.TempFile(lf.Path, lf.BaseName)
+	liveFile, err := os.CreateTemp(lf.Path, lf.BaseName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ioutils` package was deprecated in golang 1.16, so It would be better to get rid of it